### PR TITLE
adapted makefile, such that the existing bin and elf files are deleted

### DIFF
--- a/makefile
+++ b/makefile
@@ -192,7 +192,7 @@ clean:
 		  $(PROJECT_OBJECTS) \
 		  $(addprefix $(PROJECT_BUILD)arch/, $(SYS_OBJECTS)) \
 		  $(UAVCAN_OBJECTS)
-	rm -f "firmware/*.bin" "firmware/*.elf"
+	rm -f firmware/*.bin firmware/*.elf
 
 $(BL_BUILD)arch/%.o: $(ARCH_SRC)%.S
 	@mkdir -p $(@D)


### PR DESCRIPTION
when I run
`make clean` the .bin and .elf files will not get deleted. With this adaptation it works for me. I dont have much experience with makefiles so I am not sure if it is a proper fix.